### PR TITLE
Implementação de testes unitários para serviços e handlers

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -121,8 +121,8 @@ Este documento contém o planejamento detalhado e a lista de tarefas para a impl
 
 ### Testes Unitários
 - [x] Implementar testes para a camada de repositório
-- [ ] Criar testes para a camada de serviços
-- [ ] Desenvolver testes para handlers MCP
+- [x] Criar testes para a camada de serviços
+- [x] Desenvolver testes para handlers MCP
 - [ ] Implementar testes para o sistema de filtros
 - [ ] Criar testes de serialização/deserialização MCP
 
@@ -210,4 +210,4 @@ Para cada tarefa acima, seguir este processo:
 - **Data de início**: 2023-11-01
 - **Data prevista de conclusão**: 2024-05-30
 - **Fase atual**: Fase 6 - Testes (Em progresso)
-- **Progresso geral**: 95% 
+- **Progresso geral**: 97% 

--- a/tests/handlers/__init__.py
+++ b/tests/handlers/__init__.py
@@ -1,0 +1,3 @@
+"""
+Pacote de testes para a camada de handlers MCP.
+""" 

--- a/tests/handlers/test_function_handlers.py
+++ b/tests/handlers/test_function_handlers.py
@@ -1,0 +1,504 @@
+"""
+Testes unitários para os handlers de funções do MCP.
+"""
+
+import pytest
+import json
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from postgres_mcp.models.base import FunctionInfo
+from postgres_mcp.models.requests import (
+    FunctionReference, 
+    ListFunctionsRequest,
+    DescribeFunctionRequest,
+    ExecuteFunctionRequest,
+    CreateFunctionRequest,
+    DropFunctionRequest
+)
+from postgres_mcp.services.functions import FunctionService
+from postgres_mcp.handlers.functions import (
+    ListFunctionsHandler,
+    DescribeFunctionHandler,
+    ExecuteFunctionHandler,
+    CreateFunctionHandler,
+    DropFunctionHandler
+)
+
+
+@pytest.fixture
+def mock_service_container():
+    """Fixture que cria um mock do contêiner de serviços."""
+    container = MagicMock()
+    container.function_service = MagicMock(spec=FunctionService)
+    # Transformar os métodos em coroutines
+    container.function_service.list_functions = AsyncMock()
+    container.function_service.describe_function = AsyncMock()
+    container.function_service.execute_function = AsyncMock()
+    container.function_service.create_function = AsyncMock()
+    container.function_service.drop_function = AsyncMock()
+    return container
+
+
+@pytest.mark.asyncio
+async def test_list_functions_handler(mock_service_container):
+    """Testa o handler de listagem de funções."""
+    # Configura o mock para retornar funções
+    mock_service_container.function_service.list_functions.return_value = [
+        "func1", "func2", "func3"
+    ]
+    
+    # Cria o handler
+    handler = ListFunctionsHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = ListFunctionsRequest(schema="public")
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.list_functions.assert_called_once_with(
+        schema="public", 
+        include_procedures=True,
+        include_aggregates=True
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert "functions" in response
+    assert len(response["functions"]) == 3
+    assert response["functions"] == ["func1", "func2", "func3"]
+
+
+@pytest.mark.asyncio
+async def test_list_functions_handler_with_filters(mock_service_container):
+    """Testa o handler de listagem de funções com filtros."""
+    # Configura o mock para retornar funções
+    mock_service_container.function_service.list_functions.return_value = ["func1"]
+    
+    # Cria o handler
+    handler = ListFunctionsHandler(mock_service_container)
+    
+    # Cria uma requisição com filtros
+    request = ListFunctionsRequest(
+        schema="analytics",
+        include_procedures=False,
+        include_aggregates=False
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.list_functions.assert_called_once_with(
+        schema="analytics", 
+        include_procedures=False,
+        include_aggregates=False
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert len(response["functions"]) == 1
+    assert response["functions"] == ["func1"]
+
+
+@pytest.mark.asyncio
+async def test_list_functions_handler_error(mock_service_container):
+    """Testa o handler de listagem de funções quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.function_service.list_functions.side_effect = Exception("Erro de teste")
+    
+    # Cria o handler
+    handler = ListFunctionsHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = ListFunctionsRequest(schema="public")
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "Erro de teste" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_describe_function_handler(mock_service_container):
+    """Testa o handler de descrição de função."""
+    # Cria um objeto de função para retorno
+    function_info = FunctionInfo(
+        name="test_function",
+        schema="public",
+        return_type="integer",
+        definition="BEGIN RETURN 1; END;",
+        language="plpgsql",
+        argument_types=["text", "integer"],
+        argument_names=["arg1", "arg2"],
+        argument_defaults=[None, "5"],
+        is_procedure=False,
+        is_aggregate=False,
+        is_window=False,
+        is_security_definer=False,
+        volatility="stable",
+        comment="Função de teste"
+    )
+    
+    # Configura o mock para retornar a função
+    mock_service_container.function_service.describe_function.return_value = function_info
+    
+    # Cria o handler
+    handler = DescribeFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DescribeFunctionRequest(
+        function=FunctionReference(name="test_function", schema="public")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.describe_function.assert_called_once_with(
+        "test_function", "public"
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert "function" in response
+    assert response["function"]["name"] == "test_function"
+    assert response["function"]["schema"] == "public"
+    assert response["function"]["return_type"] == "integer"
+    assert response["function"]["language"] == "plpgsql"
+    assert response["function"]["is_procedure"] is False
+
+
+@pytest.mark.asyncio
+async def test_describe_function_handler_error(mock_service_container):
+    """Testa o handler de descrição de função quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.function_service.describe_function.side_effect = Exception("Função não encontrada")
+    
+    # Cria o handler
+    handler = DescribeFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DescribeFunctionRequest(
+        function=FunctionReference(name="non_existent", schema="public")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "Função não encontrada" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_function_handler_positional_args(mock_service_container):
+    """Testa o handler de execução de função com argumentos posicionais."""
+    # Configura o mock para retornar um resultado
+    mock_service_container.function_service.execute_function.return_value = 42
+    
+    # Cria o handler
+    handler = ExecuteFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição com argumentos posicionais
+    request = ExecuteFunctionRequest(
+        function=FunctionReference(name="calculate_sum", schema="public"),
+        args=[20, 22]
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.execute_function.assert_called_once_with(
+        function="calculate_sum",
+        schema="public",
+        args=[20, 22],
+        named_args=None
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert "result" in response
+    assert response["result"] == 42
+
+
+@pytest.mark.asyncio
+async def test_execute_function_handler_named_args(mock_service_container):
+    """Testa o handler de execução de função com argumentos nomeados."""
+    # Configura o mock para retornar um resultado
+    mock_service_container.function_service.execute_function.return_value = "Olá, Mundo!"
+    
+    # Cria o handler
+    handler = ExecuteFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição com argumentos nomeados
+    request = ExecuteFunctionRequest(
+        function=FunctionReference(name="format_greeting", schema="utils"),
+        named_args={"name": "Mundo", "language": "pt"}
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.execute_function.assert_called_once_with(
+        function="format_greeting",
+        schema="utils",
+        args=None,
+        named_args={"name": "Mundo", "language": "pt"}
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert response["result"] == "Olá, Mundo!"
+
+
+@pytest.mark.asyncio
+async def test_execute_function_handler_error(mock_service_container):
+    """Testa o handler de execução de função quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.function_service.execute_function.side_effect = Exception("Erro de execução")
+    
+    # Cria o handler
+    handler = ExecuteFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = ExecuteFunctionRequest(
+        function=FunctionReference(name="invalid_function", schema="public"),
+        args=[1, 2]
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "Erro de execução" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_function_handler(mock_service_container):
+    """Testa o handler de criação de função."""
+    # Cria um objeto de função para retorno
+    function_info = FunctionInfo(
+        name="new_function",
+        schema="public",
+        return_type="text",
+        definition="BEGIN RETURN 'Hello'; END;",
+        language="plpgsql",
+        is_procedure=False,
+        volatility="immutable"
+    )
+    
+    # Configura o mock para retornar a função criada
+    mock_service_container.function_service.create_function.return_value = function_info
+    
+    # Cria o handler
+    handler = CreateFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = CreateFunctionRequest(
+        function=FunctionReference(name="new_function", schema="public"),
+        definition="BEGIN RETURN 'Hello'; END;",
+        return_type="text",
+        language="plpgsql",
+        volatility="immutable",
+        replace=True
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.create_function.assert_called_once_with(
+        function="new_function",
+        schema="public",
+        definition="BEGIN RETURN 'Hello'; END;",
+        return_type="text",
+        argument_definitions=None,
+        language="plpgsql",
+        is_procedure=False,
+        replace=True,
+        security_definer=False,
+        volatility="immutable"
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert "function" in response
+    assert response["function"]["name"] == "new_function"
+    assert response["function"]["schema"] == "public"
+    assert response["function"]["return_type"] == "text"
+    assert response["function"]["definition"] == "BEGIN RETURN 'Hello'; END;"
+
+
+@pytest.mark.asyncio
+async def test_create_procedure_handler(mock_service_container):
+    """Testa o handler de criação de procedimento."""
+    # Cria um objeto de procedimento para retorno
+    procedure_info = FunctionInfo(
+        name="new_procedure",
+        schema="public",
+        return_type="void",
+        definition="BEGIN PERFORM pg_sleep(1); END;",
+        language="plpgsql",
+        is_procedure=True,
+        volatility="volatile"
+    )
+    
+    # Configura o mock para retornar o procedimento criado
+    mock_service_container.function_service.create_function.return_value = procedure_info
+    
+    # Cria o handler
+    handler = CreateFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição para um procedimento
+    request = CreateFunctionRequest(
+        function=FunctionReference(name="new_procedure", schema="public"),
+        definition="BEGIN PERFORM pg_sleep(1); END;",
+        is_procedure=True,
+        language="plpgsql"
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.create_function.assert_called_once_with(
+        function="new_procedure",
+        schema="public",
+        definition="BEGIN PERFORM pg_sleep(1); END;",
+        return_type=None,
+        argument_definitions=None,
+        language="plpgsql",
+        is_procedure=True,
+        replace=False,
+        security_definer=False,
+        volatility="volatile"  # Valor padrão para procedimentos
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert response["function"]["name"] == "new_procedure"
+    assert response["function"]["is_procedure"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_function_handler_error(mock_service_container):
+    """Testa o handler de criação de função quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.function_service.create_function.side_effect = Exception("Erro de sintaxe SQL")
+    
+    # Cria o handler
+    handler = CreateFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = CreateFunctionRequest(
+        function=FunctionReference(name="invalid_function", schema="public"),
+        definition="INVALID SQL",
+        return_type="integer"
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "Erro de sintaxe SQL" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_drop_function_handler(mock_service_container):
+    """Testa o handler de exclusão de função."""
+    # Configura o mock para retornar sucesso
+    mock_service_container.function_service.drop_function.return_value = True
+    
+    # Cria o handler
+    handler = DropFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DropFunctionRequest(
+        function=FunctionReference(name="old_function", schema="public"),
+        if_exists=True,
+        cascade=True
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.drop_function.assert_called_once_with(
+        function="old_function",
+        schema="public",
+        if_exists=True,
+        cascade=True,
+        arg_types=None
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_drop_function_with_arg_types(mock_service_container):
+    """Testa o handler de exclusão de função com tipos de argumentos."""
+    # Configura o mock para retornar sucesso
+    mock_service_container.function_service.drop_function.return_value = True
+    
+    # Cria o handler
+    handler = DropFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição com tipos de argumentos
+    request = DropFunctionRequest(
+        function=FunctionReference(
+            name="overloaded_function", 
+            schema="public", 
+            arg_types=["integer", "text"]
+        )
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.function_service.drop_function.assert_called_once_with(
+        function="overloaded_function",
+        schema="public",
+        if_exists=False,
+        cascade=False,
+        arg_types=["integer", "text"]
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_drop_function_handler_error(mock_service_container):
+    """Testa o handler de exclusão de função quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.function_service.drop_function.side_effect = Exception("Função não existe")
+    
+    # Cria o handler
+    handler = DropFunctionHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DropFunctionRequest(
+        function=FunctionReference(name="non_existent", schema="public")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "Função não existe" in response["error"] 

--- a/tests/handlers/test_view_handlers.py
+++ b/tests/handlers/test_view_handlers.py
@@ -1,0 +1,510 @@
+"""
+Testes unitários para os handlers de views do MCP.
+"""
+
+import pytest
+import json
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from postgres_mcp.models.base import ViewInfo, ColumnInfo
+from postgres_mcp.models.requests import (
+    ViewReference, 
+    ListViewsRequest,
+    DescribeViewRequest,
+    CreateViewRequest,
+    RefreshViewRequest,
+    DropViewRequest
+)
+from postgres_mcp.services.views import ViewService
+from postgres_mcp.handlers.views import (
+    ListViewsHandler,
+    DescribeViewHandler,
+    CreateViewHandler,
+    RefreshViewHandler,
+    DropViewHandler
+)
+
+
+@pytest.fixture
+def mock_service_container():
+    """Fixture que cria um mock do contêiner de serviços."""
+    container = MagicMock()
+    container.view_service = MagicMock(spec=ViewService)
+    # Transformar os métodos em coroutines
+    container.view_service.list_views = AsyncMock()
+    container.view_service.describe_view = AsyncMock()
+    container.view_service.create_view = AsyncMock()
+    container.view_service.refresh_view = AsyncMock()
+    container.view_service.drop_view = AsyncMock()
+    return container
+
+
+@pytest.mark.asyncio
+async def test_list_views_handler(mock_service_container):
+    """Testa o handler de listagem de views."""
+    # Configura o mock para retornar views
+    mock_service_container.view_service.list_views.return_value = [
+        "view1", "view2", "view3"
+    ]
+    
+    # Cria o handler
+    handler = ListViewsHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = ListViewsRequest(schema="public")
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.list_views.assert_called_once_with(
+        schema="public", 
+        include_materialized=True
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert "views" in response
+    assert len(response["views"]) == 3
+    assert response["views"] == ["view1", "view2", "view3"]
+
+
+@pytest.mark.asyncio
+async def test_list_views_non_materialized(mock_service_container):
+    """Testa o handler de listagem de views excluindo views materializadas."""
+    # Configura o mock para retornar views
+    mock_service_container.view_service.list_views.return_value = ["view1"]
+    
+    # Cria o handler
+    handler = ListViewsHandler(mock_service_container)
+    
+    # Cria uma requisição com filtros
+    request = ListViewsRequest(
+        schema="analytics",
+        include_materialized=False
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.list_views.assert_called_once_with(
+        schema="analytics", 
+        include_materialized=False
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert len(response["views"]) == 1
+    assert response["views"] == ["view1"]
+
+
+@pytest.mark.asyncio
+async def test_list_views_handler_error(mock_service_container):
+    """Testa o handler de listagem de views quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.view_service.list_views.side_effect = Exception("Erro de teste")
+    
+    # Cria o handler
+    handler = ListViewsHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = ListViewsRequest(schema="public")
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "Erro de teste" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_describe_view_handler(mock_service_container):
+    """Testa o handler de descrição de view."""
+    # Cria colunas para a view
+    columns = [
+        ColumnInfo(name="id", data_type="integer", nullable=False, is_primary=True),
+        ColumnInfo(name="name", data_type="text", nullable=False)
+    ]
+    
+    # Cria um objeto de view para retorno
+    view_info = ViewInfo(
+        name="test_view",
+        schema="public",
+        columns=columns,
+        definition="SELECT id, name FROM users",
+        is_materialized=False,
+        comment="View de teste",
+        depends_on=["public.users"]
+    )
+    
+    # Configura o mock para retornar a view
+    mock_service_container.view_service.describe_view.return_value = view_info
+    
+    # Cria o handler
+    handler = DescribeViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DescribeViewRequest(
+        view=ViewReference(name="test_view", schema="public")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.describe_view.assert_called_once_with(
+        "test_view", "public"
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert "view" in response
+    assert response["view"]["name"] == "test_view"
+    assert response["view"]["schema"] == "public"
+    assert len(response["view"]["columns"]) == 2
+    assert response["view"]["columns"][0]["name"] == "id"
+    assert response["view"]["definition"] == "SELECT id, name FROM users"
+    assert response["view"]["is_materialized"] is False
+    assert response["view"]["comment"] == "View de teste"
+    assert response["view"]["depends_on"] == ["public.users"]
+
+
+@pytest.mark.asyncio
+async def test_describe_view_handler_materialized(mock_service_container):
+    """Testa o handler de descrição de view materializada."""
+    # Cria colunas para a view
+    columns = [
+        ColumnInfo(name="month", data_type="date", nullable=False),
+        ColumnInfo(name="total", data_type="numeric", nullable=True)
+    ]
+    
+    # Cria um objeto de view materializada para retorno
+    view_info = ViewInfo(
+        name="monthly_stats",
+        schema="analytics",
+        columns=columns,
+        definition="SELECT date_trunc('month', created_at) as month, SUM(amount) as total FROM orders GROUP BY 1",
+        is_materialized=True,
+        depends_on=["public.orders"]
+    )
+    
+    # Configura o mock para retornar a view
+    mock_service_container.view_service.describe_view.return_value = view_info
+    
+    # Cria o handler
+    handler = DescribeViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DescribeViewRequest(
+        view=ViewReference(name="monthly_stats", schema="analytics")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert response["view"]["name"] == "monthly_stats"
+    assert response["view"]["schema"] == "analytics"
+    assert response["view"]["is_materialized"] is True
+    assert len(response["view"]["columns"]) == 2
+    assert response["view"]["columns"][0]["name"] == "month"
+    assert response["view"]["columns"][1]["name"] == "total"
+    assert response["view"]["depends_on"] == ["public.orders"]
+
+
+@pytest.mark.asyncio
+async def test_describe_view_handler_error(mock_service_container):
+    """Testa o handler de descrição de view quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.view_service.describe_view.side_effect = Exception("View não encontrada")
+    
+    # Cria o handler
+    handler = DescribeViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DescribeViewRequest(
+        view=ViewReference(name="non_existent", schema="public")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "View não encontrada" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_view_handler(mock_service_container):
+    """Testa o handler de criação de view."""
+    # Cria colunas para a view
+    columns = [
+        ColumnInfo(name="id", data_type="integer", nullable=False),
+        ColumnInfo(name="name", data_type="text", nullable=False)
+    ]
+    
+    # Cria um objeto de view para retorno
+    view_info = ViewInfo(
+        name="new_view",
+        schema="public",
+        columns=columns,
+        definition="SELECT id, name FROM users WHERE active = true",
+        is_materialized=False
+    )
+    
+    # Configura o mock para retornar a view criada
+    mock_service_container.view_service.create_view.return_value = view_info
+    
+    # Cria o handler
+    handler = CreateViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = CreateViewRequest(
+        view=ViewReference(name="new_view", schema="public"),
+        definition="SELECT id, name FROM users WHERE active = true",
+        replace=True
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.create_view.assert_called_once_with(
+        view="new_view",
+        schema="public",
+        definition="SELECT id, name FROM users WHERE active = true",
+        replace=True,
+        is_materialized=False,
+        columns=None,
+        with_data=True,
+        comment=None
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert "view" in response
+    assert response["view"]["name"] == "new_view"
+    assert response["view"]["schema"] == "public"
+    assert len(response["view"]["columns"]) == 2
+    assert response["view"]["definition"] == "SELECT id, name FROM users WHERE active = true"
+    assert response["view"]["is_materialized"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_materialized_view_handler(mock_service_container):
+    """Testa o handler de criação de view materializada."""
+    # Cria colunas para a view
+    columns = [
+        ColumnInfo(name="month", data_type="date", nullable=False),
+        ColumnInfo(name="total", data_type="numeric", nullable=True)
+    ]
+    
+    # Cria um objeto de view materializada para retorno
+    view_info = ViewInfo(
+        name="monthly_stats",
+        schema="analytics",
+        columns=columns,
+        definition="SELECT date_trunc('month', created_at) as month, SUM(amount) as total FROM orders GROUP BY 1",
+        is_materialized=True
+    )
+    
+    # Configura o mock para retornar a view criada
+    mock_service_container.view_service.create_view.return_value = view_info
+    
+    # Cria o handler
+    handler = CreateViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = CreateViewRequest(
+        view=ViewReference(name="monthly_stats", schema="analytics"),
+        definition="SELECT date_trunc('month', created_at) as month, SUM(amount) as total FROM orders GROUP BY 1",
+        is_materialized=True,
+        replace=True,
+        with_data=True,
+        comment="Estatísticas mensais de vendas"
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.create_view.assert_called_once_with(
+        view="monthly_stats",
+        schema="analytics",
+        definition="SELECT date_trunc('month', created_at) as month, SUM(amount) as total FROM orders GROUP BY 1",
+        replace=True,
+        is_materialized=True,
+        columns=None,
+        with_data=True,
+        comment="Estatísticas mensais de vendas"
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+    assert response["view"]["name"] == "monthly_stats"
+    assert response["view"]["schema"] == "analytics"
+    assert response["view"]["is_materialized"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_view_handler_error(mock_service_container):
+    """Testa o handler de criação de view quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.view_service.create_view.side_effect = Exception("Erro de sintaxe SQL")
+    
+    # Cria o handler
+    handler = CreateViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = CreateViewRequest(
+        view=ViewReference(name="invalid_view", schema="public"),
+        definition="INVALID SQL"
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "Erro de sintaxe SQL" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_view_handler(mock_service_container):
+    """Testa o handler de atualização de view materializada."""
+    # Configura o mock para retornar sucesso
+    mock_service_container.view_service.refresh_view.return_value = True
+    
+    # Cria o handler
+    handler = RefreshViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = RefreshViewRequest(
+        view=ViewReference(name="stats_view", schema="public"),
+        concurrently=True
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.refresh_view.assert_called_once_with(
+        view="stats_view",
+        schema="public",
+        concurrently=True
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_view_handler_error(mock_service_container):
+    """Testa o handler de atualização de view quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.view_service.refresh_view.side_effect = Exception("View não é materializada")
+    
+    # Cria o handler
+    handler = RefreshViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = RefreshViewRequest(
+        view=ViewReference(name="regular_view", schema="public")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "View não é materializada" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_drop_view_handler(mock_service_container):
+    """Testa o handler de exclusão de view."""
+    # Configura o mock para retornar sucesso
+    mock_service_container.view_service.drop_view.return_value = True
+    
+    # Cria o handler
+    handler = DropViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DropViewRequest(
+        view=ViewReference(name="old_view", schema="public"),
+        if_exists=True,
+        cascade=True
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.drop_view.assert_called_once_with(
+        view="old_view",
+        schema="public",
+        if_exists=True,
+        cascade=True
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_drop_materialized_view_handler(mock_service_container):
+    """Testa o handler de exclusão de view materializada."""
+    # Configura o mock para retornar sucesso
+    mock_service_container.view_service.drop_view.return_value = True
+    
+    # Cria o handler
+    handler = DropViewHandler(mock_service_container)
+    
+    # Cria uma requisição para view materializada
+    request = DropViewRequest(
+        view=ViewReference(name="materialized_stats", schema="analytics")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica se o serviço foi chamado corretamente
+    mock_service_container.view_service.drop_view.assert_called_once_with(
+        view="materialized_stats",
+        schema="analytics",
+        if_exists=False,
+        cascade=False
+    )
+    
+    # Verifica a resposta
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_drop_view_handler_error(mock_service_container):
+    """Testa o handler de exclusão de view quando ocorre um erro."""
+    # Configura o mock para lançar uma exceção
+    mock_service_container.view_service.drop_view.side_effect = Exception("View não existe")
+    
+    # Cria o handler
+    handler = DropViewHandler(mock_service_container)
+    
+    # Cria uma requisição
+    request = DropViewRequest(
+        view=ViewReference(name="non_existent", schema="public")
+    )
+    
+    # Executa o handler
+    response = await handler.handle(request)
+    
+    # Verifica a resposta de erro
+    assert response["success"] is False
+    assert "error" in response
+    assert "View não existe" in response["error"] 

--- a/tests/services/__init__.py
+++ b/tests/services/__init__.py
@@ -1,0 +1,3 @@
+"""
+Pacote de testes para a camada de serviços.
+""" 

--- a/tests/services/test_cache_service.py
+++ b/tests/services/test_cache_service.py
@@ -1,0 +1,274 @@
+"""
+Testes unitários para o serviço de cache.
+"""
+
+import pytest
+import time
+from unittest.mock import MagicMock, patch
+
+from postgres_mcp.core.exceptions import ServiceError
+from postgres_mcp.services.cache import CacheService
+
+
+@pytest.fixture
+def cache_service():
+    """Fixture que cria uma instância do serviço de cache."""
+    return CacheService(max_size=100, ttl=300)
+
+
+def test_cache_service_init():
+    """Testa a inicialização do serviço de cache com diferentes parâmetros."""
+    # Cache com valores padrão
+    cache = CacheService()
+    assert cache.max_size == 1000
+    assert cache.ttl == 3600  # 1 hora
+    
+    # Cache com valores personalizados
+    cache = CacheService(max_size=500, ttl=60)
+    assert cache.max_size == 500
+    assert cache.ttl == 60
+    
+    # Cache com TTL desativado
+    cache = CacheService(ttl=None)
+    assert cache.ttl is None
+
+
+def test_set_get_cache(cache_service):
+    """Testa as operações básicas de definir e obter do cache."""
+    # Define um valor no cache
+    cache_service.set("test_key", "test_value")
+    
+    # Obtém o valor do cache
+    result = cache_service.get("test_key")
+    
+    # Verifica o resultado
+    assert result == "test_value"
+    
+    # Tenta obter uma chave inexistente
+    result = cache_service.get("non_existent_key")
+    assert result is None
+    
+    # Tenta obter uma chave inexistente com valor padrão
+    result = cache_service.get("non_existent_key", default="default_value")
+    assert result == "default_value"
+
+
+def test_set_with_namespace(cache_service):
+    """Testa a definição de valores no cache com namespace."""
+    # Define valores com diferentes namespaces
+    cache_service.set("key1", "value1", namespace="ns1")
+    cache_service.set("key1", "value2", namespace="ns2")
+    
+    # Verifica que são armazenados separadamente
+    assert cache_service.get("key1", namespace="ns1") == "value1"
+    assert cache_service.get("key1", namespace="ns2") == "value2"
+
+
+def test_cache_expiration():
+    """Testa a expiração de itens no cache."""
+    # Cria cache com TTL curto
+    cache = CacheService(ttl=0.1)  # 100ms
+    
+    # Define um valor no cache
+    cache.set("test_key", "test_value")
+    
+    # Verifica que está disponível imediatamente
+    assert cache.get("test_key") == "test_value"
+    
+    # Espera a expiração
+    time.sleep(0.2)  # 200ms
+    
+    # Verifica que o valor expirou
+    assert cache.get("test_key") is None
+
+
+def test_cache_item_ttl(cache_service):
+    """Testa a definição de TTL específico para um item."""
+    # Define um valor com TTL curto
+    cache_service.set("short_lived", "value", ttl=0.1)
+    
+    # Define um valor com TTL padrão
+    cache_service.set("long_lived", "value")
+    
+    # Verifica que ambos estão disponíveis imediatamente
+    assert cache_service.get("short_lived") == "value"
+    assert cache_service.get("long_lived") == "value"
+    
+    # Espera a expiração do primeiro item
+    time.sleep(0.2)
+    
+    # Verifica que o primeiro expirou, mas o segundo continua disponível
+    assert cache_service.get("short_lived") is None
+    assert cache_service.get("long_lived") == "value"
+
+
+def test_delete_from_cache(cache_service):
+    """Testa a remoção de itens do cache."""
+    # Define alguns valores no cache
+    cache_service.set("key1", "value1")
+    cache_service.set("key2", "value2")
+    cache_service.set("key3", "value3", namespace="custom")
+    
+    # Verifica que estão disponíveis
+    assert cache_service.get("key1") == "value1"
+    assert cache_service.get("key2") == "value2"
+    assert cache_service.get("key3", namespace="custom") == "value3"
+    
+    # Remove um item
+    result = cache_service.delete("key1")
+    assert result is True
+    assert cache_service.get("key1") is None
+    
+    # Tenta remover um item inexistente
+    result = cache_service.delete("non_existent_key")
+    assert result is False
+    
+    # Remove um item de um namespace específico
+    result = cache_service.delete("key3", namespace="custom")
+    assert result is True
+    assert cache_service.get("key3", namespace="custom") is None
+    
+    # Verifica que outros itens permanecem intactos
+    assert cache_service.get("key2") == "value2"
+
+
+def test_clear_cache(cache_service):
+    """Testa a limpeza do cache."""
+    # Define alguns valores no cache
+    cache_service.set("key1", "value1")
+    cache_service.set("key2", "value2")
+    cache_service.set("key3", "value3", namespace="ns1")
+    cache_service.set("key4", "value4", namespace="ns1")
+    cache_service.set("key5", "value5", namespace="ns2")
+    
+    # Limpa um namespace específico
+    cache_service.clear(namespace="ns1")
+    
+    # Verifica que apenas os itens do namespace foram limpos
+    assert cache_service.get("key1") == "value1"
+    assert cache_service.get("key2") == "value2"
+    assert cache_service.get("key3", namespace="ns1") is None
+    assert cache_service.get("key4", namespace="ns1") is None
+    assert cache_service.get("key5", namespace="ns2") == "value5"
+    
+    # Limpa todo o cache
+    cache_service.clear()
+    
+    # Verifica que todos os itens foram limpos
+    assert cache_service.get("key1") is None
+    assert cache_service.get("key2") is None
+    assert cache_service.get("key5", namespace="ns2") is None
+
+
+def test_cache_stats(cache_service):
+    """Testa a coleta de estatísticas do cache."""
+    # Define alguns valores e faz algumas consultas
+    cache_service.set("key1", "value1")
+    cache_service.set("key2", "value2")
+    
+    # Hits
+    cache_service.get("key1")
+    cache_service.get("key1")
+    cache_service.get("key2")
+    
+    # Misses
+    cache_service.get("key3")
+    cache_service.get("key4")
+    
+    # Obtém estatísticas
+    stats = cache_service.get_stats()
+    
+    # Verifica estatísticas
+    assert stats["hits"] == 3
+    assert stats["misses"] == 2
+    assert stats["size"] == 2
+    assert stats["max_size"] == 100
+    assert 0.5 <= stats["hit_ratio"] <= 0.6  # 3/(3+2) = 0.6
+    
+    # Limpa o cache e verifica que as estatísticas são reiniciadas
+    cache_service.clear()
+    cache_service.reset_stats()
+    
+    stats = cache_service.get_stats()
+    assert stats["hits"] == 0
+    assert stats["misses"] == 0
+    assert stats["size"] == 0
+
+
+def test_cache_size_limit():
+    """Testa o limite de tamanho do cache."""
+    # Cria um cache com tamanho pequeno
+    cache = CacheService(max_size=3)
+    
+    # Define itens no cache até o limite
+    cache.set("key1", "value1")
+    cache.set("key2", "value2")
+    cache.set("key3", "value3")
+    
+    # Verifica que todos os itens estão no cache
+    assert cache.get("key1") == "value1"
+    assert cache.get("key2") == "value2"
+    assert cache.get("key3") == "value3"
+    
+    # Adiciona um novo item, que deve causar a remoção do item menos recentemente usado
+    cache.set("key4", "value4")
+    
+    # Verifica que o item mais antigo foi removido (LRU)
+    assert cache.get("key1") is None
+    assert cache.get("key2") == "value2"
+    assert cache.get("key3") == "value3"
+    assert cache.get("key4") == "value4"
+
+
+def test_cache_with_complex_objects(cache_service):
+    """Testa o cache com objetos complexos."""
+    # Define um dicionário como valor
+    dict_value = {"name": "test", "values": [1, 2, 3]}
+    cache_service.set("dict_key", dict_value)
+    
+    # Verifica que o objeto foi armazenado corretamente
+    result = cache_service.get("dict_key")
+    assert result == dict_value
+    assert result["name"] == "test"
+    assert result["values"] == [1, 2, 3]
+    
+    # Define uma lista como valor
+    list_value = [{"id": 1}, {"id": 2}]
+    cache_service.set("list_key", list_value)
+    
+    # Verifica que a lista foi armazenada corretamente
+    result = cache_service.get("list_key")
+    assert result == list_value
+    assert len(result) == 2
+    assert result[0]["id"] == 1
+
+
+def test_cache_contains(cache_service):
+    """Testa o método contains do cache."""
+    # Define valores no cache
+    cache_service.set("key1", "value1")
+    cache_service.set("key2", "value2", namespace="custom")
+    
+    # Verifica existência de chaves
+    assert "key1" in cache_service
+    assert "key2" not in cache_service  # Sem especificar namespace
+    assert cache_service.contains("key2", namespace="custom")
+    assert not cache_service.contains("key3")
+
+
+def test_multi_get_set(cache_service):
+    """Testa as operações de get e set múltiplos."""
+    # Define vários valores de uma vez
+    data = {"key1": "value1", "key2": "value2", "key3": "value3"}
+    cache_service.multi_set(data)
+    
+    # Obtém vários valores de uma vez
+    keys = ["key1", "key2", "key4"]  # Inclui uma chave inexistente
+    results = cache_service.multi_get(keys)
+    
+    # Verifica os resultados
+    assert results == {"key1": "value1", "key2": "value2", "key4": None}
+    
+    # Com valor padrão
+    results = cache_service.multi_get(keys, default="not_found")
+    assert results == {"key1": "value1", "key2": "value2", "key4": "not_found"} 

--- a/tests/services/test_function_service.py
+++ b/tests/services/test_function_service.py
@@ -1,0 +1,395 @@
+"""
+Testes unitários para o serviço de funções.
+"""
+
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from postgres_mcp.core.exceptions import ServiceError
+from postgres_mcp.models.base import FunctionInfo
+from postgres_mcp.services.functions import FunctionService
+
+
+@pytest.fixture
+def mock_repository():
+    """Fixture que cria um mock do repositório PostgreSQL."""
+    mock = MagicMock()
+    # Transformar os métodos em coroutines
+    mock.get_functions = AsyncMock()
+    mock.describe_function = AsyncMock()
+    mock.execute_function = AsyncMock()
+    mock.create_function = AsyncMock()
+    mock.drop_function = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def function_service(mock_repository):
+    """Fixture que cria uma instância do serviço de funções com o repositório mockado."""
+    return FunctionService(repository=mock_repository)
+
+
+@pytest.mark.asyncio
+async def test_list_functions_success(function_service, mock_repository):
+    """Testa a listagem de funções com sucesso."""
+    # Configura o mock para retornar uma lista de funções
+    mock_repository.get_functions.return_value = ["func1", "func2", "func3"]
+    
+    # Chama o método e verifica o resultado
+    result = await function_service.list_functions("public")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.get_functions.assert_called_once_with(
+        schema="public", 
+        include_procedures=True,
+        include_aggregates=True
+    )
+    
+    # Verifica o resultado
+    assert result == ["func1", "func2", "func3"]
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_functions_with_filters(function_service, mock_repository):
+    """Testa a listagem de funções com filtros."""
+    # Configura o mock para retornar uma lista de funções
+    mock_repository.get_functions.return_value = ["func1"]
+    
+    # Chama o método com filtros e verifica o resultado
+    result = await function_service.list_functions(
+        schema="analytics",
+        include_procedures=False,
+        include_aggregates=False
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.get_functions.assert_called_once_with(
+        schema="analytics", 
+        include_procedures=False,
+        include_aggregates=False
+    )
+    
+    # Verifica o resultado
+    assert result == ["func1"]
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_functions_error(function_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao listar funções."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.get_functions.side_effect = Exception("Erro de teste")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await function_service.list_functions("public")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao listar funções: Erro de teste" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_describe_function_success(function_service, mock_repository):
+    """Testa a descrição de uma função com sucesso."""
+    # Configura o mock para retornar dados da função
+    mock_function_data = {
+        "name": "test_function",
+        "schema": "public",
+        "return_type": "integer",
+        "definition": "BEGIN RETURN 1; END;",
+        "language": "plpgsql",
+        "argument_types": ["text", "integer"],
+        "argument_names": ["arg1", "arg2"],
+        "argument_defaults": [None, "5"],
+        "is_procedure": False,
+        "is_aggregate": False,
+        "is_window": False,
+        "is_security_definer": False,
+        "volatility": "stable",
+        "comment": "Função de teste"
+    }
+    mock_repository.describe_function.return_value = mock_function_data
+    
+    # Chama o método e verifica o resultado
+    result = await function_service.describe_function("test_function", "public")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.describe_function.assert_called_once_with("test_function", "public")
+    
+    # Verifica o resultado
+    assert isinstance(result, FunctionInfo)
+    assert result.name == "test_function"
+    assert result.schema == "public"
+    assert result.return_type == "integer"
+    assert result.definition == "BEGIN RETURN 1; END;"
+    assert result.language == "plpgsql"
+    assert result.argument_types == ["text", "integer"]
+    assert result.argument_names == ["arg1", "arg2"]
+    assert result.argument_defaults == [None, "5"]
+    assert result.is_procedure is False
+    assert result.is_aggregate is False
+    assert result.is_window is False
+    assert result.is_security_definer is False
+    assert result.volatility == "stable"
+    assert result.comment == "Função de teste"
+
+
+@pytest.mark.asyncio
+async def test_describe_function_error(function_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao descrever uma função."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.describe_function.side_effect = Exception("Função não encontrada")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await function_service.describe_function("non_existent_function", "public")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao descrever função public.non_existent_function:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_execute_function_success(function_service, mock_repository):
+    """Testa a execução de uma função com sucesso."""
+    # Configura o mock para retornar um resultado
+    mock_repository.execute_function.return_value = 42
+    
+    # Chama o método com argumentos posicionais
+    result = await function_service.execute_function(
+        function="calculate_sum",
+        schema="public",
+        args=[20, 22]
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.execute_function.assert_called_once_with(
+        function="calculate_sum",
+        schema="public",
+        args=[20, 22],
+        named_args=None
+    )
+    
+    # Verifica o resultado
+    assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_execute_function_with_named_args(function_service, mock_repository):
+    """Testa a execução de uma função com argumentos nomeados."""
+    # Configura o mock para retornar um resultado
+    mock_repository.execute_function.return_value = "Olá, Mundo!"
+    
+    # Chama o método com argumentos nomeados
+    result = await function_service.execute_function(
+        function="format_greeting",
+        schema="utils",
+        named_args={"name": "Mundo", "language": "pt"}
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.execute_function.assert_called_once_with(
+        function="format_greeting",
+        schema="utils",
+        args=None,
+        named_args={"name": "Mundo", "language": "pt"}
+    )
+    
+    # Verifica o resultado
+    assert result == "Olá, Mundo!"
+
+
+@pytest.mark.asyncio
+async def test_execute_function_error(function_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao executar uma função."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.execute_function.side_effect = Exception("Erro ao executar função")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await function_service.execute_function("calculate_sum", "public", [1, 2])
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao executar função public.calculate_sum:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_create_function_success(function_service, mock_repository):
+    """Testa a criação de uma função com sucesso."""
+    # Configura o mock para retornar dados da função criada
+    mock_function_data = {
+        "name": "new_function",
+        "schema": "public",
+        "return_type": "text",
+        "definition": "BEGIN RETURN 'Hello'; END;",
+        "language": "plpgsql",
+        "is_procedure": False,
+        "volatility": "immutable"
+    }
+    mock_repository.create_function.return_value = mock_function_data
+    
+    # Chama o método e verifica o resultado
+    result = await function_service.create_function(
+        function="new_function",
+        definition="BEGIN RETURN 'Hello'; END;",
+        return_type="text",
+        schema="public",
+        language="plpgsql",
+        volatility="immutable"
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.create_function.assert_called_once_with(
+        function="new_function",
+        definition="BEGIN RETURN 'Hello'; END;",
+        return_type="text",
+        schema="public",
+        argument_definitions=None,
+        language="plpgsql",
+        is_procedure=False,
+        replace=False,
+        security_definer=False,
+        volatility="immutable"
+    )
+    
+    # Verifica o resultado
+    assert isinstance(result, FunctionInfo)
+    assert result.name == "new_function"
+    assert result.schema == "public"
+    assert result.return_type == "text"
+    assert result.definition == "BEGIN RETURN 'Hello'; END;"
+    assert result.language == "plpgsql"
+    assert result.is_procedure is False
+    assert result.volatility == "immutable"
+
+
+@pytest.mark.asyncio
+async def test_create_procedure_success(function_service, mock_repository):
+    """Testa a criação de um procedimento com sucesso."""
+    # Configura o mock para retornar dados do procedimento criado
+    mock_procedure_data = {
+        "name": "new_procedure",
+        "schema": "public",
+        "return_type": "void",
+        "definition": "BEGIN PERFORM pg_sleep(1); END;",
+        "language": "plpgsql",
+        "is_procedure": True,
+        "volatility": "volatile"
+    }
+    mock_repository.create_function.return_value = mock_procedure_data
+    
+    # Chama o método e verifica o resultado
+    result = await function_service.create_function(
+        function="new_procedure",
+        definition="BEGIN PERFORM pg_sleep(1); END;",
+        return_type="void",
+        schema="public",
+        language="plpgsql",
+        is_procedure=True
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.create_function.assert_called_once_with(
+        function="new_procedure",
+        definition="BEGIN PERFORM pg_sleep(1); END;",
+        return_type="void",
+        schema="public",
+        argument_definitions=None,
+        language="plpgsql",
+        is_procedure=True,
+        replace=False,
+        security_definer=False,
+        volatility="volatile"
+    )
+    
+    # Verifica o resultado
+    assert isinstance(result, FunctionInfo)
+    assert result.name == "new_procedure"
+    assert result.is_procedure is True
+
+
+@pytest.mark.asyncio
+async def test_create_function_error(function_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao criar uma função."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.create_function.side_effect = Exception("Erro de sintaxe")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await function_service.create_function(
+            function="invalid_function",
+            definition="INVALID SQL",
+            return_type="integer",
+            schema="public"
+        )
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao criar função public.invalid_function:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_drop_function_success(function_service, mock_repository):
+    """Testa a exclusão de uma função com sucesso."""
+    # Configura o mock para retornar sucesso
+    mock_repository.drop_function.return_value = True
+    
+    # Chama o método e verifica o resultado
+    result = await function_service.drop_function(
+        function="old_function",
+        schema="public",
+        if_exists=True,
+        cascade=True
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.drop_function.assert_called_once_with(
+        function="old_function",
+        schema="public",
+        if_exists=True,
+        cascade=True,
+        arg_types=None
+    )
+    
+    # Verifica o resultado
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_drop_function_with_arg_types(function_service, mock_repository):
+    """Testa a exclusão de uma função específica com tipos de argumentos."""
+    # Configura o mock para retornar sucesso
+    mock_repository.drop_function.return_value = True
+    
+    # Chama o método e verifica o resultado
+    result = await function_service.drop_function(
+        function="overloaded_function",
+        schema="public",
+        arg_types=["integer", "text"]
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.drop_function.assert_called_once_with(
+        function="overloaded_function",
+        schema="public",
+        if_exists=False,
+        cascade=False,
+        arg_types=["integer", "text"]
+    )
+    
+    # Verifica o resultado
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_drop_function_error(function_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao excluir uma função."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.drop_function.side_effect = Exception("Função não existe")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await function_service.drop_function("non_existent_function", "public")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao excluir função public.non_existent_function:" in str(excinfo.value) 

--- a/tests/services/test_transaction_service.py
+++ b/tests/services/test_transaction_service.py
@@ -1,0 +1,201 @@
+"""
+Testes unitários para o serviço de transações.
+"""
+
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from postgres_mcp.core.exceptions import ServiceError
+from postgres_mcp.services.transaction import TransactionService
+
+
+@pytest.fixture
+def mock_repository():
+    """Fixture que cria um mock do repositório PostgreSQL."""
+    mock = MagicMock()
+    mock.begin_transaction = AsyncMock()
+    mock.commit_transaction = AsyncMock()
+    mock.rollback_transaction = AsyncMock()
+    mock.get_transaction_status = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def transaction_service(mock_repository):
+    """Fixture que cria uma instância do serviço de transações com o repositório mockado."""
+    return TransactionService(repository=mock_repository)
+
+
+@pytest.mark.asyncio
+async def test_begin_transaction_success(transaction_service, mock_repository):
+    """Testa o início de uma transação com sucesso."""
+    # Configura o mock para retornar sucesso
+    mock_repository.begin_transaction.return_value = "tx_1234"
+    
+    # Chama o método e verifica o resultado
+    transaction_id = await transaction_service.begin_transaction()
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.begin_transaction.assert_called_once()
+    
+    # Verifica o resultado
+    assert transaction_id == "tx_1234"
+
+
+@pytest.mark.asyncio
+async def test_begin_transaction_error(transaction_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao iniciar uma transação."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.begin_transaction.side_effect = Exception("Erro ao iniciar transação")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await transaction_service.begin_transaction()
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao iniciar transação:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_commit_transaction_success(transaction_service, mock_repository):
+    """Testa o commit de uma transação com sucesso."""
+    # Configura o mock para retornar sucesso
+    mock_repository.commit_transaction.return_value = True
+    
+    # Chama o método e verifica o resultado
+    result = await transaction_service.commit_transaction("tx_1234")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.commit_transaction.assert_called_once_with("tx_1234")
+    
+    # Verifica o resultado
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_commit_transaction_error(transaction_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao fazer commit de uma transação."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.commit_transaction.side_effect = Exception("Transação não existe")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await transaction_service.commit_transaction("tx_invalid")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao fazer commit da transação tx_invalid:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_rollback_transaction_success(transaction_service, mock_repository):
+    """Testa o rollback de uma transação com sucesso."""
+    # Configura o mock para retornar sucesso
+    mock_repository.rollback_transaction.return_value = True
+    
+    # Chama o método e verifica o resultado
+    result = await transaction_service.rollback_transaction("tx_1234")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.rollback_transaction.assert_called_once_with("tx_1234")
+    
+    # Verifica o resultado
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_rollback_transaction_error(transaction_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao fazer rollback de uma transação."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.rollback_transaction.side_effect = Exception("Transação já finalizada")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await transaction_service.rollback_transaction("tx_finished")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao fazer rollback da transação tx_finished:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_status_success(transaction_service, mock_repository):
+    """Testa a obtenção do status de uma transação com sucesso."""
+    # Configura o mock para retornar um status
+    mock_repository.get_transaction_status.return_value = {
+        "id": "tx_1234",
+        "status": "active",
+        "started_at": "2023-01-01T12:00:00Z",
+        "query_count": 5
+    }
+    
+    # Chama o método e verifica o resultado
+    result = await transaction_service.get_transaction_status("tx_1234")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.get_transaction_status.assert_called_once_with("tx_1234")
+    
+    # Verifica o resultado
+    assert result["id"] == "tx_1234"
+    assert result["status"] == "active"
+    assert result["started_at"] == "2023-01-01T12:00:00Z"
+    assert result["query_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_status_error(transaction_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao obter o status de uma transação."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.get_transaction_status.side_effect = Exception("Transação não encontrada")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await transaction_service.get_transaction_status("tx_unknown")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao obter status da transação tx_unknown:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_transaction_context_manager_success():
+    """Testa o uso do gerenciador de contexto para transações com sucesso."""
+    # Cria um mock para o repositório
+    mock_repo = MagicMock()
+    mock_repo.begin_transaction = AsyncMock(return_value="tx_1234")
+    mock_repo.commit_transaction = AsyncMock(return_value=True)
+    
+    # Cria o serviço
+    service = TransactionService(repository=mock_repo)
+    
+    # Usa o gerenciador de contexto
+    async with service.transaction() as tx_id:
+        assert tx_id == "tx_1234"
+    
+    # Verifica se begin e commit foram chamados
+    mock_repo.begin_transaction.assert_called_once()
+    mock_repo.commit_transaction.assert_called_once_with("tx_1234")
+    # Rollback não deve ter sido chamado
+    mock_repo.rollback_transaction.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_transaction_context_manager_error():
+    """Testa o gerenciador de contexto para transações quando ocorre um erro."""
+    # Cria um mock para o repositório
+    mock_repo = MagicMock()
+    mock_repo.begin_transaction = AsyncMock(return_value="tx_1234")
+    mock_repo.rollback_transaction = AsyncMock(return_value=True)
+    
+    # Cria o serviço
+    service = TransactionService(repository=mock_repo)
+    
+    # Usa o gerenciador de contexto com uma exceção
+    with pytest.raises(ValueError):
+        async with service.transaction() as tx_id:
+            assert tx_id == "tx_1234"
+            raise ValueError("Erro durante a transação")
+    
+    # Verifica se begin e rollback foram chamados
+    mock_repo.begin_transaction.assert_called_once()
+    mock_repo.rollback_transaction.assert_called_once_with("tx_1234")
+    # Commit não deve ter sido chamado
+    mock_repo.commit_transaction.assert_not_called() 

--- a/tests/services/test_view_service.py
+++ b/tests/services/test_view_service.py
@@ -1,0 +1,394 @@
+"""
+Testes unitários para o serviço de views.
+"""
+
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from postgres_mcp.core.exceptions import ServiceError
+from postgres_mcp.models.base import ViewInfo, ColumnInfo
+from postgres_mcp.services.views import ViewService
+
+
+@pytest.fixture
+def mock_repository():
+    """Fixture que cria um mock do repositório PostgreSQL."""
+    mock = MagicMock()
+    # Transformar os métodos em coroutines
+    mock.get_views = AsyncMock()
+    mock.describe_view = AsyncMock()
+    mock.create_view = AsyncMock()
+    mock.refresh_view = AsyncMock()
+    mock.drop_view = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def view_service(mock_repository):
+    """Fixture que cria uma instância do serviço de views com o repositório mockado."""
+    return ViewService(repository=mock_repository)
+
+
+@pytest.mark.asyncio
+async def test_list_views_success(view_service, mock_repository):
+    """Testa a listagem de views com sucesso."""
+    # Configura o mock para retornar uma lista de views
+    mock_repository.get_views.return_value = ["view1", "view2", "view3"]
+    
+    # Chama o método e verifica o resultado
+    result = await view_service.list_views("public")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.get_views.assert_called_once_with(
+        schema="public", 
+        include_materialized=True
+    )
+    
+    # Verifica o resultado
+    assert result == ["view1", "view2", "view3"]
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_views_non_materialized(view_service, mock_repository):
+    """Testa a listagem de views excluindo views materializadas."""
+    # Configura o mock para retornar uma lista de views
+    mock_repository.get_views.return_value = ["view1"]
+    
+    # Chama o método com filtros e verifica o resultado
+    result = await view_service.list_views(
+        schema="analytics",
+        include_materialized=False
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.get_views.assert_called_once_with(
+        schema="analytics", 
+        include_materialized=False
+    )
+    
+    # Verifica o resultado
+    assert result == ["view1"]
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_views_error(view_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao listar views."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.get_views.side_effect = Exception("Erro de teste")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await view_service.list_views("public")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao listar views: Erro de teste" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_describe_view_success(view_service, mock_repository):
+    """Testa a descrição de uma view com sucesso."""
+    # Configura o mock para retornar dados da view
+    mock_view_data = {
+        "name": "test_view",
+        "schema": "public",
+        "columns": [
+            {
+                "name": "id",
+                "data_type": "integer",
+                "nullable": False,
+                "is_primary": True
+            },
+            {
+                "name": "name",
+                "data_type": "text",
+                "nullable": False
+            }
+        ],
+        "definition": "SELECT id, name FROM users",
+        "is_materialized": False,
+        "comment": "View de teste",
+        "depends_on": ["public.users"]
+    }
+    mock_repository.describe_view.return_value = mock_view_data
+    
+    # Chama o método e verifica o resultado
+    result = await view_service.describe_view("test_view", "public")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.describe_view.assert_called_once_with("test_view", "public")
+    
+    # Verifica o resultado
+    assert isinstance(result, ViewInfo)
+    assert result.name == "test_view"
+    assert result.schema == "public"
+    assert len(result.columns) == 2
+    assert isinstance(result.columns[0], ColumnInfo)
+    assert result.columns[0].name == "id"
+    assert result.columns[0].data_type == "integer"
+    assert result.columns[0].nullable is False
+    assert result.columns[0].is_primary is True
+    assert result.columns[1].name == "name"
+    assert result.definition == "SELECT id, name FROM users"
+    assert result.is_materialized is False
+    assert result.comment == "View de teste"
+    assert result.depends_on == ["public.users"]
+
+
+@pytest.mark.asyncio
+async def test_describe_materialized_view(view_service, mock_repository):
+    """Testa a descrição de uma view materializada."""
+    # Configura o mock para retornar dados da view materializada
+    mock_view_data = {
+        "name": "test_materialized",
+        "schema": "public",
+        "columns": [
+            {
+                "name": "id",
+                "data_type": "integer",
+                "nullable": False
+            },
+            {
+                "name": "count",
+                "data_type": "bigint",
+                "nullable": True
+            }
+        ],
+        "definition": "SELECT id, COUNT(*) FROM orders GROUP BY id",
+        "is_materialized": True,
+        "depends_on": ["public.orders"]
+    }
+    mock_repository.describe_view.return_value = mock_view_data
+    
+    # Chama o método e verifica o resultado
+    result = await view_service.describe_view("test_materialized", "public")
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.describe_view.assert_called_once_with("test_materialized", "public")
+    
+    # Verifica o resultado
+    assert isinstance(result, ViewInfo)
+    assert result.name == "test_materialized"
+    assert result.is_materialized is True
+    assert len(result.columns) == 2
+    assert result.columns[1].name == "count"
+    assert result.columns[1].data_type == "bigint"
+
+
+@pytest.mark.asyncio
+async def test_describe_view_error(view_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao descrever uma view."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.describe_view.side_effect = Exception("View não encontrada")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await view_service.describe_view("non_existent_view", "public")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao descrever view public.non_existent_view:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_create_view_success(view_service, mock_repository):
+    """Testa a criação de uma view com sucesso."""
+    # Configura o mock para retornar dados da view criada
+    mock_view_data = {
+        "name": "new_view",
+        "schema": "public",
+        "columns": [
+            {
+                "name": "id",
+                "data_type": "integer",
+                "nullable": False
+            },
+            {
+                "name": "name",
+                "data_type": "text",
+                "nullable": False
+            }
+        ],
+        "definition": "SELECT id, name FROM users WHERE active = true",
+        "is_materialized": False
+    }
+    mock_repository.create_view.return_value = mock_view_data
+    
+    # Chama o método e verifica o resultado
+    result = await view_service.create_view(
+        view="new_view",
+        definition="SELECT id, name FROM users WHERE active = true",
+        schema="public",
+        replace=True
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.create_view.assert_called_once_with(
+        view="new_view",
+        definition="SELECT id, name FROM users WHERE active = true",
+        schema="public",
+        replace=True,
+        is_materialized=False,
+        columns=None,
+        with_data=True,
+        comment=None
+    )
+    
+    # Verifica o resultado
+    assert isinstance(result, ViewInfo)
+    assert result.name == "new_view"
+    assert result.schema == "public"
+    assert len(result.columns) == 2
+    assert result.definition == "SELECT id, name FROM users WHERE active = true"
+    assert result.is_materialized is False
+
+
+@pytest.mark.asyncio
+async def test_create_materialized_view(view_service, mock_repository):
+    """Testa a criação de uma view materializada."""
+    # Configura o mock para retornar dados da view materializada
+    mock_view_data = {
+        "name": "monthly_stats",
+        "schema": "analytics",
+        "columns": [
+            {
+                "name": "month",
+                "data_type": "date",
+                "nullable": False
+            },
+            {
+                "name": "total",
+                "data_type": "numeric",
+                "nullable": True
+            }
+        ],
+        "definition": "SELECT date_trunc('month', created_at) as month, SUM(amount) as total FROM orders GROUP BY 1",
+        "is_materialized": True
+    }
+    mock_repository.create_view.return_value = mock_view_data
+    
+    # Chama o método e verifica o resultado
+    result = await view_service.create_view(
+        view="monthly_stats",
+        definition="SELECT date_trunc('month', created_at) as month, SUM(amount) as total FROM orders GROUP BY 1",
+        schema="analytics",
+        is_materialized=True,
+        replace=True,
+        with_data=True,
+        comment="Estatísticas mensais de vendas"
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.create_view.assert_called_once_with(
+        view="monthly_stats",
+        definition="SELECT date_trunc('month', created_at) as month, SUM(amount) as total FROM orders GROUP BY 1",
+        schema="analytics",
+        replace=True,
+        is_materialized=True,
+        columns=None,
+        with_data=True,
+        comment="Estatísticas mensais de vendas"
+    )
+    
+    # Verifica o resultado
+    assert isinstance(result, ViewInfo)
+    assert result.name == "monthly_stats"
+    assert result.schema == "analytics"
+    assert result.is_materialized is True
+
+
+@pytest.mark.asyncio
+async def test_create_view_error(view_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao criar uma view."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.create_view.side_effect = Exception("Erro de sintaxe SQL")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await view_service.create_view(
+            view="invalid_view",
+            definition="INVALID SQL",
+            schema="public"
+        )
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao criar view public.invalid_view:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_view_success(view_service, mock_repository):
+    """Testa a atualização de uma view materializada com sucesso."""
+    # Configura o mock para retornar sucesso
+    mock_repository.refresh_view.return_value = True
+    
+    # Chama o método e verifica o resultado
+    result = await view_service.refresh_view(
+        view="stats_view",
+        schema="public",
+        concurrently=True
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.refresh_view.assert_called_once_with(
+        view="stats_view",
+        schema="public",
+        concurrently=True
+    )
+    
+    # Verifica o resultado
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_view_error(view_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao atualizar uma view."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.refresh_view.side_effect = Exception("View não é materializada")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await view_service.refresh_view("non_materialized_view", "public")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao atualizar view public.non_materialized_view:" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_drop_view_success(view_service, mock_repository):
+    """Testa a exclusão de uma view com sucesso."""
+    # Configura o mock para retornar sucesso
+    mock_repository.drop_view.return_value = True
+    
+    # Chama o método e verifica o resultado
+    result = await view_service.drop_view(
+        view="old_view",
+        schema="public",
+        if_exists=True,
+        cascade=True
+    )
+    
+    # Verifica se o método do repositório foi chamado corretamente
+    mock_repository.drop_view.assert_called_once_with(
+        view="old_view",
+        schema="public",
+        if_exists=True,
+        cascade=True
+    )
+    
+    # Verifica o resultado
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_drop_view_error(view_service, mock_repository):
+    """Testa o comportamento quando ocorre um erro ao excluir uma view."""
+    # Configura o mock para lançar uma exceção
+    mock_repository.drop_view.side_effect = Exception("View não existe")
+    
+    # Verifica se a exceção ServiceError é lançada
+    with pytest.raises(ServiceError) as excinfo:
+        await view_service.drop_view("non_existent_view", "public")
+    
+    # Verifica a mensagem de erro
+    assert "Erro ao excluir view public.non_existent_view:" in str(excinfo.value) 


### PR DESCRIPTION
Esta PR adiciona testes unitários para a camada de serviços e handlers do MCP, incluindo:\n\n- Testes para FunctionService e ViewService\n- Testes para CacheService e TransactionService\n- Testes para handlers de funções e procedures\n- Testes para handlers de views e views materializadas\n\nA implementação aumenta a cobertura de testes e avança o projeto para 97% de conclusão.